### PR TITLE
reduce csi loglevel

### DIFF
--- a/examples/rook-operator-nodeSelector/kustomization.yml
+++ b/examples/rook-operator-nodeSelector/kustomization.yml
@@ -11,3 +11,11 @@ bases:
 
 patchesStrategicMerge:
   - rook-operator-nodeSelector.yml
+
+configMapGenerator:
+  # this will slow down the log amount of the CSI components that otherwise is too high
+  - name : rook-ceph-operator-config
+    namespace: rook-ceph
+    behavior: merge
+    literals:
+    - CSI_LOG_LEVEL=0

--- a/katalog/rook-operator/rook-ceph-operator-config-cm.yaml
+++ b/katalog/rook-operator/rook-ceph-operator-config-cm.yaml
@@ -53,7 +53,7 @@ data:
 
   # Set logging level for cephCSI containers maintained by the cephCSI.
   # Supported values from 0 to 5. 0 for general useful logs, 5 for trace level verbosity.
-  CSI_LOG_LEVEL: "0"
+  # CSI_LOG_LEVEL: "0"
 
   # Set logging level for Kubernetes-csi sidecar containers.
   # Supported values from 0 to 5. 0 for general useful logs (the default), 5 for trace level verbosity.

--- a/katalog/rook-operator/rook-ceph-operator-config-cm.yaml
+++ b/katalog/rook-operator/rook-ceph-operator-config-cm.yaml
@@ -53,7 +53,7 @@ data:
 
   # Set logging level for cephCSI containers maintained by the cephCSI.
   # Supported values from 0 to 5. 0 for general useful logs, 5 for trace level verbosity.
-  # CSI_LOG_LEVEL: "0"
+  CSI_LOG_LEVEL: "0"
 
   # Set logging level for Kubernetes-csi sidecar containers.
   # Supported values from 0 to 5. 0 for general useful logs (the default), 5 for trace level verbosity.


### PR DESCRIPTION
Hi!
this patch aims to reduce noticeably the amount of logging produced by the ceph components.
This make the services more efficient and the amount of logging  readable, compared with the default that is very very high.
